### PR TITLE
Approximate timesync and topic renaming

### DIFF
--- a/include/msckf_vio/image_processor.h
+++ b/include/msckf_vio/image_processor.h
@@ -377,7 +377,7 @@ private:
     sensor_msgs::Image> cam0_img_sub;
   message_filters::Subscriber<
     sensor_msgs::Image> cam1_img_sub;
-  message_filters::TimeSynchronizer<
+  message_filters::ApproximateTimeSynchronizer<
     sensor_msgs::Image, sensor_msgs::Image> stereo_sub;
   ros::Subscriber imu_sub;
   ros::Publisher feature_pub;

--- a/include/msckf_vio/image_processor.h
+++ b/include/msckf_vio/image_processor.h
@@ -21,6 +21,8 @@
 #include <sensor_msgs/Image.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
 
 namespace msckf_vio {
 
@@ -377,8 +379,11 @@ private:
     sensor_msgs::Image> cam0_img_sub;
   message_filters::Subscriber<
     sensor_msgs::Image> cam1_img_sub;
-  message_filters::ApproximateTimeSynchronizer<
-    sensor_msgs::Image, sensor_msgs::Image> stereo_sub;
+  // message_filters::TimeSynchronizer<
+  //   sensor_msgs::Image, sensor_msgs::Image> stereo_sub;
+  typedef message_filters::sync_policies::ApproximateTime<
+      sensor_msgs::Image, sensor_msgs::Image> StereoSyncPolicy;
+  message_filters::Synchronizer<StereoSyncPolicy> stereo_sub;
   ros::Subscriber imu_sub;
   ros::Publisher feature_pub;
   ros::Publisher tracking_info_pub;

--- a/launch/image_processor_cmu.launch
+++ b/launch/image_processor_cmu.launch
@@ -24,8 +24,8 @@
       <param name="stereo_threshold" value="5"/>
 
       <remap from="~imu" to="/vectornav/IMU"/>
-      <remap from="~cam0_image" to="/left/camera/image_color"/>
-      <remap from="~cam1_image" to="/right/camera/image_color"/>
+      <remap from="~cam0_image" to="/left/camera/image_rect"/>
+      <remap from="~cam1_image" to="/right/camera/image_rect"/>
 
     </node>
   </group>

--- a/launch/image_processor_cmu.launch
+++ b/launch/image_processor_cmu.launch
@@ -24,8 +24,8 @@
       <param name="stereo_threshold" value="5"/>
 
       <remap from="~imu" to="/vectornav/IMU"/>
-      <remap from="~cam0_image" to="/left/camera/image_rect"/>
-      <remap from="~cam1_image" to="/right/camera/image_rect"/>
+      <remap from="~cam0_image" to="/left/camera/image_mono"/>
+      <remap from="~cam1_image" to="/right/camera/image_mono"/>
 
     </node>
   </group>

--- a/launch/msckf_vio_cmu.launch
+++ b/launch/msckf_vio_cmu.launch
@@ -1,10 +1,8 @@
 <launch>
-
   <arg name="robot" default="firefly_sbx"/>
   <arg name="fixed_frame_id" default="world"/>
   <arg name="calibration_file"
     default="$(find msckf_vio)/config/camchain-imucam-cmu-fullframe.yaml"/>
-
   <!-- Debayering Nodelet  -->
   <include file="$(find msckf_vio)/launch/debayer_cmu.launch"></include>
   <!-- Image Processor Nodelet  -->
@@ -23,7 +21,7 @@
       <rosparam command="load" file="$(arg calibration_file)"/>
 
       <param name="publish_tf" value="true"/>
-      <param name="frame_rate" value="7"/>
+      <param name="frame_rate" value="4"/>
       <param name="fixed_frame_id" value="$(arg fixed_frame_id)"/>
       <param name="child_frame_id" value="odom"/>
       <param name="max_cam_state_size" value="20"/>
@@ -54,7 +52,7 @@
       <param name="initial_covariance/extrinsic_rotation_cov" value="3.0462e-4"/>
       <param name="initial_covariance/extrinsic_translation_cov" value="2.5e-5"/>
 
-      <remap from="~imu" to="/imu0"/>
+      <remap from="~imu" to="/vectornav/IMU"/>
       <remap from="~features" to="image_processor/features"/>
 
     </node>

--- a/rviz/rviz_cmu_config.rviz
+++ b/rviz/rviz_cmu_config.rviz
@@ -253,7 +253,7 @@ Visualization Manager:
       Value: false
     - Class: rviz/Image
       Enabled: true
-      Image Topic: /right/camera/image_mono
+      Image Topic: /right/camera/image_rect
       Max Value: 1
       Median window: 5
       Min Value: 0
@@ -265,7 +265,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: /right/camera/image_mono
+      Image Topic: /left/camera/image_rect
       Max Value: 1
       Median window: 5
       Min Value: 0

--- a/rviz/rviz_cmu_config.rviz
+++ b/rviz/rviz_cmu_config.rviz
@@ -253,7 +253,7 @@ Visualization Manager:
       Value: false
     - Class: rviz/Image
       Enabled: true
-      Image Topic: /right/camera/image_rect
+      Image Topic: /right/camera/image_mono
       Max Value: 1
       Median window: 5
       Min Value: 0
@@ -265,7 +265,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: true
-      Image Topic: /left/camera/image_rect
+      Image Topic: /left/camera/image_mono
       Max Value: 1
       Median window: 5
       Min Value: 0

--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -184,6 +184,8 @@ bool ImageProcessor::createRosIO() {
 
   cam0_img_sub.subscribe(nh, "cam0_image", 10);
   cam1_img_sub.subscribe(nh, "cam1_image", 10);
+  // Allowed slop in seconds
+  stereo_sub.setMaxIntervalDuration(0.01);
   stereo_sub.connectInput(cam0_img_sub, cam1_img_sub);
   stereo_sub.registerCallback(&ImageProcessor::stereoCallback, this);
   imu_sub = nh.subscribe("imu", 50,

--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -27,7 +27,7 @@ ImageProcessor::ImageProcessor(ros::NodeHandle& n) :
   nh(n),
   is_first_img(true),
   //img_transport(n),
-  stereo_sub(10),
+  stereo_sub(StereoSyncPolicy(10)),
   prev_features_ptr(new GridFeatures()),
   curr_features_ptr(new GridFeatures()) {
   return;
@@ -184,8 +184,6 @@ bool ImageProcessor::createRosIO() {
 
   cam0_img_sub.subscribe(nh, "cam0_image", 10);
   cam1_img_sub.subscribe(nh, "cam1_image", 10);
-  // Allowed slop in seconds
-  stereo_sub.setMaxIntervalDuration(0.01);
   stereo_sub.connectInput(cam0_img_sub, cam1_img_sub);
   stereo_sub.registerCallback(&ImageProcessor::stereoCallback, this);
   imu_sub = nh.subscribe("imu", 50,

--- a/src/msckf_vio.cpp
+++ b/src/msckf_vio.cpp
@@ -240,6 +240,7 @@ void MsckfVio::imuCallback(
     //if (imu_msg_buffer.size() < 10) return;
     initializeGravityAndBias();
     is_gravity_set = true;
+    ROS_INFO("Gravity initialized from buffered IMU data");
   }
 
   return;


### PR DESCRIPTION
This adds an approximate timesync policy. My commit fixes the name of the topic, which was leading to distortion issues. 